### PR TITLE
Refactored initialisation code to a generic abstract class

### DIFF
--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/AssignmentInsideSubExpression.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/AssignmentInsideSubExpression.cs
@@ -1,21 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Text;
-using System.Collections.Immutable;
-using System.Threading;
-
-namespace NSonarQubeAnalyzer
+﻿namespace NSonarQubeAnalyzer.Diagnostics
 {
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using System.Collections.Immutable;
+
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class AssignmentInsideSubExpression : DiagnosticAnalyzer
+    public class AssignmentInsideSubExpression : DiagnosticsRule
     {
         internal const string DiagnosticId = "AssignmentInsideSubExpression";
         internal const string Description = "Assignment should not be used inside sub-expressions";
@@ -24,6 +16,17 @@ namespace NSonarQubeAnalyzer
         internal const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Description, MessageFormat, Category, Severity, true);
+
+        /// <summary>
+        /// Rule ID
+        /// </summary>
+        public override string RuleId
+        {
+            get
+            {
+                return "AssignmentInsideSubExpression";
+            }
+        }
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/AsyncAwaitIdentifier.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/AsyncAwaitIdentifier.cs
@@ -1,21 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Text;
-using System.Collections.Immutable;
-using System.Threading;
-
-namespace NSonarQubeAnalyzer
+﻿namespace NSonarQubeAnalyzer.Diagnostics
 {
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class AsyncAwaitIdentifier : DiagnosticAnalyzer
+    public class AsyncAwaitIdentifier : DiagnosticsRule
     {
         internal const string DiagnosticId = "AsyncAwaitIdentifier";
         internal const string Description = "'async' and 'await' should not be used as identifier";
@@ -25,7 +18,18 @@ namespace NSonarQubeAnalyzer
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Description, MessageFormat, Category, Severity, true);
 
-        private static readonly IImmutableSet<string> ASYNC_OR_AWAIT = ImmutableHashSet.Create(new string[] {"async", "await"});
+        private static readonly IImmutableSet<string> ASYNC_OR_AWAIT = ImmutableHashSet.Create(new[] {"async", "await"});
+
+        /// <summary>
+        /// Rule ID
+        /// </summary>
+        public override string RuleId
+        {
+            get
+            {
+                return "AsyncAwaitIdentifier";
+            }
+        }
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/AtLeastThreeCasesInSwitch.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/AtLeastThreeCasesInSwitch.cs
@@ -1,21 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Text;
-using System.Collections.Immutable;
-using System.Threading;
-
-namespace NSonarQubeAnalyzer
+﻿namespace NSonarQubeAnalyzer.Diagnostics
 {
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using System.Collections.Immutable;
+    using System.Linq;
+
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class AtLeastThreeCasesInSwitch : DiagnosticAnalyzer
+    public class AtLeastThreeCasesInSwitch : DiagnosticsRule
     {
         internal const string DiagnosticId = "S1301";
         internal const string Description = "\"switch\" statements should have at least 3 \"case\" clauses";
@@ -24,6 +17,17 @@ namespace NSonarQubeAnalyzer
         internal const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Description, MessageFormat, Category, Severity, true);
+
+        /// <summary>
+        /// Rule ID
+        /// </summary>
+        public override string RuleId
+        {
+            get
+            {
+                return "S1301";
+            }
+        }
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/BreakOutsideSwitch.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/BreakOutsideSwitch.cs
@@ -1,21 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Text;
-using System.Collections.Immutable;
-using System.Threading;
-
-namespace NSonarQubeAnalyzer
+﻿namespace NSonarQubeAnalyzer.Diagnostics
 {
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using System.Collections.Immutable;
+
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class BreakOutsideSwitch : DiagnosticAnalyzer
+    public class BreakOutsideSwitch : DiagnosticsRule
     {
         internal const string DiagnosticId = "BreakOutsideSwitch";
         internal const string Description = "'break' should not be used outside of 'switch'";
@@ -24,6 +16,17 @@ namespace NSonarQubeAnalyzer
         internal const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Description, MessageFormat, Category, Severity, true);
+
+        /// <summary>
+        /// Rule ID
+        /// </summary>
+        public override string RuleId
+        {
+            get
+            {
+                return "BreakOutsideSwitch";
+            }
+        }
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/ClassName.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/ClassName.cs
@@ -1,22 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Text;
-using System.Collections.Immutable;
-using System.Threading;
-using System.Text.RegularExpressions;
-
-namespace NSonarQubeAnalyzer
+﻿namespace NSonarQubeAnalyzer.Diagnostics
 {
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+    using System.Xml.Linq;
+
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class ClassName : DiagnosticAnalyzer
+    public class ClassName : DiagnosticsRule
     {
         internal const string DiagnosticId = "S101";
         internal const string Description = "Class name should comply with a naming convention";
@@ -26,9 +20,37 @@ namespace NSonarQubeAnalyzer
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Description, MessageFormat, Category, Severity, true);
 
+        /// <summary>
+        /// Rule ID
+        /// </summary>
+        public override string RuleId
+        {
+            get
+            {
+                return "ClassName";
+            }
+        }
+
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 
-        public string Convention;
+        public string Convention { get; set; }
+
+        /// <summary>
+        /// Configure the rule from the supplied settings
+        /// </summary>
+        /// <param name="settings">XML settings</param>
+        public override void Configure(XDocument settings)
+        {
+            var parameters = from e in settings.Descendants("Rule")
+                             where "ClassName".Equals(e.Elements("Key").Single().Value)
+                             select e.Descendants("Parameter");
+            var convention = (from e in parameters
+                              where "format".Equals(e.Elements("Key").Single().Value)
+                              select e.Elements("Value").Single().Value)
+                          .Single();
+
+            this.Convention = convention;
+        }
 
         public override void Initialize(AnalysisContext context)
         {
@@ -37,9 +59,9 @@ namespace NSonarQubeAnalyzer
                 {
                     var identifier = ((ClassDeclarationSyntax)c.Node).Identifier;
 
-                    if (!Regex.IsMatch(identifier.Text, Convention))
+                    if (!Regex.IsMatch(identifier.Text, this.Convention))
                     {
-                        c.ReportDiagnostic(Diagnostic.Create(Rule, identifier.GetLocation(), Convention));
+                        c.ReportDiagnostic(Diagnostic.Create(Rule, identifier.GetLocation(), this.Convention));
                     }
                 },
                 SyntaxKind.ClassDeclaration);

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/CommentRegularExpression.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/CommentRegularExpression.cs
@@ -1,19 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
-using System.Collections.Immutable;
-using System.Threading;
-using System.Text.RegularExpressions;
-
-namespace NSonarQubeAnalyzer
+﻿namespace NSonarQubeAnalyzer.Diagnostics
 {
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+    using System.Xml.Linq;
+
     public class CommentRegularExpressionRule
     {
         public DiagnosticDescriptor Descriptor;
@@ -21,11 +15,66 @@ namespace NSonarQubeAnalyzer
     }
 
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class CommentRegularExpression : DiagnosticAnalyzer
+    public class CommentRegularExpression : DiagnosticsRule
     {
-        public ImmutableArray<CommentRegularExpressionRule> Rules;
+        public ImmutableArray<CommentRegularExpressionRule> Rules { get; set; }
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return Rules.Select(r => r.Descriptor).ToImmutableArray(); } }
+        /// <summary>
+        /// Rule ID
+        /// </summary>
+        public override string RuleId
+        {
+            get
+            {
+                return "CommentRegularExpression";
+            }
+        }
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return this.Rules.Select(r => r.Descriptor).ToImmutableArray(); } }
+
+        /// <summary>
+        /// Configure the rule from the supplied settings
+        /// </summary>
+        /// <param name="settings">XML settings</param>
+        public override void Configure(XDocument settings)
+        {
+            var commentRegexpRules = from e in settings.Descendants("Rule")
+                                     where
+                                         this.RuleId.Equals(
+                                             (e.Elements("ParentKey").SingleOrDefault() ?? XElement.Parse("<Dummy />")).Value)
+                                     select e;
+
+            if (!commentRegexpRules.Any())
+            {
+                return;
+            }
+
+            var builder = ImmutableArray.CreateBuilder<CommentRegularExpressionRule>();
+
+            foreach (var commentRegexpRule in commentRegexpRules)
+            {
+                string key = commentRegexpRule.Elements("Key").Single().Value;
+                var parameters = commentRegexpRule.Descendants("Parameter");
+                string message =
+                    (from e in parameters
+                     where "message".Equals(e.Elements("Key").Single().Value)
+                     select e.Elements("Value").Single().Value).Single();
+                string regularExpression = (from e in parameters
+                                            where "regularExpression".Equals(e.Elements("Key").Single().Value)
+                                            select e.Elements("Value").Single().Value).Single();
+
+                builder.Add(
+                    new CommentRegularExpressionRule
+                    {
+                        // TODO: Add rule description
+                        Descriptor =
+                            new DiagnosticDescriptor(key, "TODO", message, "SonarQube", DiagnosticSeverity.Warning, true),
+                        RegularExpression = regularExpression
+                    });
+
+                this.Rules = builder.ToImmutable();
+            }
+        }
 
         public override void Initialize(AnalysisContext context)
         {
@@ -39,7 +88,7 @@ namespace NSonarQubeAnalyzer
                     foreach (var comment in comments)
                     {
                         var text = comment.ToString();
-                        foreach (var rule in Rules)
+                        foreach (var rule in this.Rules)
                         {
                             if (Regex.IsMatch(text, rule.RegularExpression))
                             {

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/CommentRegularExpression.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/CommentRegularExpression.cs
@@ -10,8 +10,9 @@
 
     public class CommentRegularExpressionRule
     {
-        public DiagnosticDescriptor Descriptor;
-        public string RegularExpression;
+        public DiagnosticDescriptor Descriptor { get; set; }
+
+        public string RegularExpression { get; set; }
     }
 
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -39,9 +40,7 @@
         public override void Configure(XDocument settings)
         {
             var commentRegexpRules = from e in settings.Descendants("Rule")
-                                     where
-                                         this.RuleId.Equals(
-                                             (e.Elements("ParentKey").SingleOrDefault() ?? XElement.Parse("<Dummy />")).Value)
+                                     where this.RuleId.Equals(e.Elements("Key").Single().Value)
                                      select e;
 
             if (!commentRegexpRules.Any())
@@ -53,7 +52,7 @@
 
             foreach (var commentRegexpRule in commentRegexpRules)
             {
-                string key = commentRegexpRule.Elements("Key").Single().Value;
+                string key = commentRegexpRule.Elements("ChildKey").Single().Value;
                 var parameters = commentRegexpRule.Descendants("Parameter");
                 string message =
                     (from e in parameters
@@ -71,9 +70,9 @@
                             new DiagnosticDescriptor(key, "TODO", message, "SonarQube", DiagnosticSeverity.Warning, true),
                         RegularExpression = regularExpression
                     });
-
-                this.Rules = builder.ToImmutable();
             }
+
+            this.Rules = builder.ToImmutable();
         }
 
         public override void Initialize(AnalysisContext context)

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/CommentedOutCode.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/CommentedOutCode.cs
@@ -1,20 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
-using System.Collections.Immutable;
-using System.Threading;
-
-namespace NSonarQubeAnalyzer
+﻿namespace NSonarQubeAnalyzer.Diagnostics
 {
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class CommentedOutCode : DiagnosticAnalyzer
+    public class CommentedOutCode : DiagnosticsRule
     {
         internal const string DiagnosticId = "CommentedCode";
         internal const string Description = "Comment should not include code";
@@ -23,6 +17,17 @@ namespace NSonarQubeAnalyzer
         internal const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Description, MessageFormat, Category, Severity, true);
+
+        /// <summary>
+        /// Rule ID
+        /// </summary>
+        public override string RuleId
+        {
+            get
+            {
+                return "CommentedCode";
+            }
+        }
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 
@@ -54,7 +59,7 @@ namespace NSonarQubeAnalyzer
 
                                         for (int offset = 0; offset < lines.Length; offset++)
                                         {
-                                            if (IsCode(lines[offset]))
+                                            if (this.IsCode(lines[offset]))
                                             {
                                                 int lineNumber = baseLineNumber + offset;
                                                 int oldLastCommentedCodeLine = lastCommentedCodeLine;

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/ElseIfWithoutElse.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/ElseIfWithoutElse.cs
@@ -1,21 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Text;
-using System.Collections.Immutable;
-using System.Threading;
-
-namespace NSonarQubeAnalyzer
+﻿namespace NSonarQubeAnalyzer.Diagnostics
 {
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using System.Collections.Immutable;
+
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class ElseIfWithoutElse : DiagnosticAnalyzer
+    public class ElseIfWithoutElse : DiagnosticsRule
     {
         internal const string DiagnosticId = "S126";
         internal const string Description = "\"if ... else if\" constructs shall be terminated with an \"else\" clause";
@@ -24,6 +16,17 @@ namespace NSonarQubeAnalyzer
         internal const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Description, MessageFormat, Category, Severity, true);
+
+        /// <summary>
+        /// Rule ID
+        /// </summary>
+        public override string RuleId
+        {
+            get
+            {
+                return "S126";
+            }
+        }
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/EmptyMethod.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/EmptyMethod.cs
@@ -1,20 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
-using System.Collections.Immutable;
-using System.Threading;
-
-namespace NSonarQubeAnalyzer
+﻿namespace NSonarQubeAnalyzer.Diagnostics
 {
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using System.Collections.Immutable;
+    using System.Linq;
+
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class EmptyMethod : DiagnosticAnalyzer
+    public class EmptyMethod : DiagnosticsRule
     {
         internal const string DiagnosticId = "S1186";
         internal const string Description = "Methods should not be empty";
@@ -23,6 +17,17 @@ namespace NSonarQubeAnalyzer
         internal const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Description, MessageFormat, Category, Severity, true);
+
+        /// <summary>
+        /// Rule ID
+        /// </summary>
+        public override string RuleId
+        {
+            get
+            {
+                return "S1186";
+            }
+        }
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/EmptyNestedBlock.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/EmptyNestedBlock.cs
@@ -1,20 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
-using System.Collections.Immutable;
-using System.Threading;
-
-namespace NSonarQubeAnalyzer
+﻿namespace NSonarQubeAnalyzer.Diagnostics
 {
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using System.Collections.Immutable;
+    using System.Linq;
+
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class EmptyNestedBlock : DiagnosticAnalyzer
+    public class EmptyNestedBlock : DiagnosticsRule
     {
         internal const string DiagnosticId = "S108";
         internal const string Description = "Nested blocks of code should not be left empty";
@@ -23,6 +17,17 @@ namespace NSonarQubeAnalyzer
         internal const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Description, MessageFormat, Category, Severity, true);
+
+        /// <summary>
+        /// Rule ID
+        /// </summary>
+        public override string RuleId
+        {
+            get
+            {
+                return "S108";
+            }
+        }
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/EmptyStatement.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/EmptyStatement.cs
@@ -1,20 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
-using System.Collections.Immutable;
-using System.Threading;
-
-namespace NSonarQubeAnalyzer
+﻿namespace NSonarQubeAnalyzer.Diagnostics
 {
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using System.Collections.Immutable;
+
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class EmptyStatement : DiagnosticAnalyzer
+    public class EmptyStatement : DiagnosticsRule
     {
         internal const string DiagnosticId = "S1116";
         internal const string Description = "Empty statements should be removed";
@@ -23,6 +15,17 @@ namespace NSonarQubeAnalyzer
         internal const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Description, MessageFormat, Category, Severity, true);
+
+        /// <summary>
+        /// Rule ID
+        /// </summary>
+        public override string RuleId
+        {
+            get
+            {
+                return "S1116";
+            }
+        }
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/ForLoopCounterChanged.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/ForLoopCounterChanged.cs
@@ -1,21 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Text;
-using System.Collections.Immutable;
-using System.Threading;
-
-namespace NSonarQubeAnalyzer
+﻿namespace NSonarQubeAnalyzer.Diagnostics
 {
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class ForLoopCounterChanged : DiagnosticAnalyzer
+    public class ForLoopCounterChanged : DiagnosticsRule
     {
         internal const string DiagnosticId = "S127";
         internal const string Description = "A loop's counter should not be assigned within the loop body";
@@ -24,6 +19,17 @@ namespace NSonarQubeAnalyzer
         internal const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Description, MessageFormat, Category, Severity, true);
+
+        /// <summary>
+        /// Rule ID
+        /// </summary>
+        public override string RuleId
+        {
+            get
+            {
+                return "S127";
+            }
+        }
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/IfConditionalAlwaysTrueOrFalse.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/IfConditionalAlwaysTrueOrFalse.cs
@@ -1,21 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Text;
-using System.Collections.Immutable;
-using System.Threading;
-
-namespace NSonarQubeAnalyzer
+﻿namespace NSonarQubeAnalyzer.Diagnostics
 {
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using System.Collections.Immutable;
+
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class IfConditionalAlwaysTrueOrFalse : DiagnosticAnalyzer
+    public class IfConditionalAlwaysTrueOrFalse : DiagnosticsRule
     {
         internal const string DiagnosticId = "S1145";
         internal const string Description = "\"if\" statement conditions should not unconditionally evaluate to \"true\" or to \"false\"";
@@ -24,6 +16,17 @@ namespace NSonarQubeAnalyzer
         internal const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Description, MessageFormat, Category, Severity, true);
+
+        /// <summary>
+        /// Rule ID
+        /// </summary>
+        public override string RuleId
+        {
+            get
+            {
+                return "S1145";
+            }
+        }
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/LineLength.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/LineLength.cs
@@ -1,21 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Text;
-using System.Collections.Immutable;
-using System.Threading;
-
-namespace NSonarQubeAnalyzer
+﻿namespace NSonarQubeAnalyzer.Diagnostics
 {
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Xml.Linq;
+
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class LineLength : DiagnosticAnalyzer
+    public class LineLength : DiagnosticsRule
     {
         internal const string DiagnosticId = "LineLength";
         internal const string Description = "Lines should not be too long";
@@ -25,9 +17,36 @@ namespace NSonarQubeAnalyzer
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Description, MessageFormat, Category, Severity, true);
 
+        /// <summary>
+        /// Rule ID
+        /// </summary>
+        public override string RuleId
+        {
+            get
+            {
+                return "LineLength";
+            }
+        }
+
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 
-        public int Maximum;
+        public int Maximum { get; set; }
+
+        /// <summary>
+        /// Configure the rule from the supplied settings
+        /// </summary>
+        /// <param name="settings">XML settings</param>
+        public override void Configure(XDocument settings)
+        {
+            var parameters = from e in settings.Descendants("Rule")
+                             where this.RuleId.Equals(e.Elements("Key").Single().Value)
+                             select e.Descendants("Parameter");
+            var maximum = (from e in parameters
+                           where "maximumLineLength".Equals(e.Elements("Key").Single().Value)
+                           select e.Elements("Value").Single().Value).Single();
+
+            this.Maximum = int.Parse(maximum);
+        }
 
         public override void Initialize(AnalysisContext context)
         {
@@ -36,9 +55,9 @@ namespace NSonarQubeAnalyzer
                 {
                     foreach (var line in c.Tree.GetText().Lines)
                     {
-                        if (line.Span.Length > Maximum)
+                        if (line.Span.Length > this.Maximum)
                         {
-                            c.ReportDiagnostic(Diagnostic.Create(Rule, c.Tree.GetLocation(line.Span), Maximum, line.Span.Length));
+                            c.ReportDiagnostic(Diagnostic.Create(Rule, c.Tree.GetLocation(line.Span), this.Maximum, line.Span.Length));
                         }
                     }
                 });

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/MethodName.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/MethodName.cs
@@ -1,22 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Text;
-using System.Collections.Immutable;
-using System.Threading;
-using System.Text.RegularExpressions;
-
-namespace NSonarQubeAnalyzer
+﻿namespace NSonarQubeAnalyzer.Diagnostics
 {
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+    using System.Xml.Linq;
+
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class MethodName : DiagnosticAnalyzer
+    public class MethodName : DiagnosticsRule
     {
         internal const string DiagnosticId = "S100";
         internal const string Description = "Method name should comply with a naming convention";
@@ -26,9 +20,37 @@ namespace NSonarQubeAnalyzer
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Description, MessageFormat, Category, Severity, true);
 
+        /// <summary>
+        /// Rule ID
+        /// </summary>
+        public override string RuleId
+        {
+            get
+            {
+                return "MethodName";
+            }
+        }
+
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 
-        public string Convention;
+        public string Convention { get; set; }
+
+        /// <summary>
+        /// Configure the rule from the supplied settings
+        /// </summary>
+        /// <param name="settings">XML settings</param>
+        public override void Configure(XDocument settings)
+        {
+            var parameters = from e in settings.Descendants("Rule")
+                             where "MethodName".Equals(e.Elements("Key").Single().Value)
+                             select e.Descendants("Parameter");
+            var convention =
+                (from e in parameters
+                 where "format".Equals(e.Elements("Key").Single().Value)
+                 select e.Elements("Value").Single().Value).Single();
+
+            this.Convention = convention;
+        }
 
         public override void Initialize(AnalysisContext context)
         {
@@ -37,9 +59,9 @@ namespace NSonarQubeAnalyzer
                 {
                     var identifierNode = ((MethodDeclarationSyntax)c.Node).Identifier;
 
-                    if (!Regex.IsMatch(identifierNode.Text, Convention))
+                    if (!Regex.IsMatch(identifierNode.Text, this.Convention))
                     {
-                        c.ReportDiagnostic(Diagnostic.Create(Rule, identifierNode.GetLocation(), Convention));
+                        c.ReportDiagnostic(Diagnostic.Create(Rule, identifierNode.GetLocation(), this.Convention));
                     }
                 },
                 SyntaxKind.MethodDeclaration);

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/ParameterAssignedTo.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/ParameterAssignedTo.cs
@@ -1,20 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
-using System.Collections.Immutable;
-using System.Threading;
-
-namespace NSonarQubeAnalyzer
+﻿namespace NSonarQubeAnalyzer.Diagnostics
 {
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using System.Collections.Immutable;
+
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class ParameterAssignedTo : DiagnosticAnalyzer
+    public class ParameterAssignedTo : DiagnosticsRule
     {
         internal const string DiagnosticId = "ParameterAssignedTo";
         internal const string Description = "Parameter variable should not be assigned to";
@@ -23,6 +16,17 @@ namespace NSonarQubeAnalyzer
         internal const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Description, MessageFormat, Category, Severity, true);
+
+        /// <summary>
+        /// Rule ID
+        /// </summary>
+        public override string RuleId
+        {
+            get
+            {
+                return "ParameterAssignedTo";
+            }
+        }
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 
@@ -34,7 +38,7 @@ namespace NSonarQubeAnalyzer
                     var assignmentNode = (AssignmentExpressionSyntax)c.Node;
                     var symbol = c.SemanticModel.GetSymbolInfo(assignmentNode.Left).Symbol;
 
-                    if (symbol != null && AssignsToParameter(symbol))
+                    if (symbol != null && this.AssignsToParameter(symbol))
                     {
                         c.ReportDiagnostic(Diagnostic.Create(Rule, assignmentNode.GetLocation(), assignmentNode.Left.ToString()));
                     }

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/RightCurlyBraceStartsLine.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/RightCurlyBraceStartsLine.cs
@@ -1,21 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Text;
-using System.Collections.Immutable;
-using System.Threading;
-
-namespace NSonarQubeAnalyzer
+﻿namespace NSonarQubeAnalyzer.Diagnostics
 {
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class RightCurlyBraceStartsLine : DiagnosticAnalyzer
+    public class RightCurlyBraceStartsLine : DiagnosticsRule
     {
         internal const string DiagnosticId = "S1109";
         internal const string Description = "A close curly brace should be located at the beginning of a line";
@@ -24,6 +17,17 @@ namespace NSonarQubeAnalyzer
         internal const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Description, MessageFormat, Category, Severity, true);
+
+        /// <summary>
+        /// Rule ID
+        /// </summary>
+        public override string RuleId
+        {
+            get
+            {
+                return "S1109";
+            }
+        }
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 
@@ -34,7 +38,7 @@ namespace NSonarQubeAnalyzer
                 {
                     foreach (var closeBraceToken in GetDescendantCloseBraceTokens(c.Node))
                     {
-                        if (!StartsLine(closeBraceToken) && !IsOnSameLineAsOpenBrace(closeBraceToken) && !IsInitializer(closeBraceToken.Parent))
+                        if (!StartsLine(closeBraceToken) && !IsOnSameLineAsOpenBrace(closeBraceToken) && !this.IsInitializer(closeBraceToken.Parent))
                         {
                             c.ReportDiagnostic(Diagnostic.Create(Rule, closeBraceToken.GetLocation()));
                         }

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/SwitchWithoutDefault.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/SwitchWithoutDefault.cs
@@ -1,21 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Text;
-using System.Collections.Immutable;
-using System.Threading;
-
-namespace NSonarQubeAnalyzer
+﻿namespace NSonarQubeAnalyzer.Diagnostics
 {
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using System.Collections.Immutable;
+    using System.Linq;
+
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class SwitchWithoutDefault : DiagnosticAnalyzer
+    public class SwitchWithoutDefault : DiagnosticsRule
     {
         internal const string DiagnosticId = "SwitchWithoutDefault";
         internal const string Description = "'switch' statement should have a 'default:' case";
@@ -24,6 +17,17 @@ namespace NSonarQubeAnalyzer
         internal const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Description, MessageFormat, Category, Severity, true);
+
+        /// <summary>
+        /// Rule ID
+        /// </summary>
+        public override string RuleId
+        {
+            get
+            {
+                return "SwitchWithoutDefault";
+            }
+        }
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/TabCharacter.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/TabCharacter.cs
@@ -1,21 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Text;
-using System.Collections.Immutable;
-using System.Threading;
-
-namespace NSonarQubeAnalyzer
+﻿namespace NSonarQubeAnalyzer.Diagnostics
 {
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using Microsoft.CodeAnalysis.Text;
+    using System.Collections.Immutable;
+
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class TabCharacter : DiagnosticAnalyzer
+    public class TabCharacter : DiagnosticsRule
     {
         internal const string DiagnosticId = "TabCharacter";
         internal const string Description = "Tabulation character should not be used";
@@ -24,6 +15,17 @@ namespace NSonarQubeAnalyzer
         internal const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Description, MessageFormat, Category, Severity, true);
+
+        /// <summary>
+        /// Rule ID
+        /// </summary>
+        public override string RuleId
+        {
+            get
+            {
+                return "TabCharacter";
+            }
+        }
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/UnnecessaryBooleanLiteral.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/UnnecessaryBooleanLiteral.cs
@@ -1,20 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
-using System.Collections.Immutable;
-using System.Threading;
-
-namespace NSonarQubeAnalyzer
+﻿namespace NSonarQubeAnalyzer.Diagnostics
 {
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using System.Collections.Immutable;
+
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class UnnecessaryBooleanLiteral : DiagnosticAnalyzer
+    public class UnnecessaryBooleanLiteral : DiagnosticsRule
     {
         internal const string DiagnosticId = "S1125";
         internal const string Description = "Literal boolean values should not be used in condition expressions";
@@ -23,6 +16,17 @@ namespace NSonarQubeAnalyzer
         internal const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Description, MessageFormat, Category, Severity, true);
+
+        /// <summary>
+        /// Rule ID
+        /// </summary>
+        public override string RuleId
+        {
+            get
+            {
+                return "S1125";
+            }
+        }
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/UnusedLocalVariable.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/UnusedLocalVariable.cs
@@ -1,21 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.FindSymbols;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
-using System.Collections.Immutable;
-using System.Threading;
-
-namespace NSonarQubeAnalyzer
+﻿namespace NSonarQubeAnalyzer.Diagnostics
 {
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using System.Collections.Immutable;
+    using System.Linq;
+
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class UnusedLocalVariable : DiagnosticAnalyzer
+    public class UnusedLocalVariable : DiagnosticsRule
     {
         internal const string DiagnosticId = "S1481";
         internal const string Description = "Unused local variables should be removed";
@@ -24,6 +17,17 @@ namespace NSonarQubeAnalyzer
         internal const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Description, MessageFormat, Category, Severity, true);
+
+        /// <summary>
+        /// Rule ID
+        /// </summary>
+        public override string RuleId
+        {
+            get
+            {
+                return "S1481";
+            }
+        }
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 
@@ -41,7 +45,7 @@ namespace NSonarQubeAnalyzer
                         .Where(e => e.IsKind(SyntaxKind.VariableDeclarator))
                         .Select(e => (VariableDeclaratorSyntax)e);
 
-                    var referencedSymbols = ReferencedSymbols(syntaxTree, semanticModel);
+                    var referencedSymbols = this.ReferencedSymbols(syntaxTree, semanticModel);
 
                     foreach (var variableDeclaratorNode in variableDeclaratorNodes)
                     {

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/UseCurlyBraces.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Diagnostics/UseCurlyBraces.cs
@@ -1,20 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
-using System.Collections.Immutable;
-using System.Threading;
-
-namespace NSonarQubeAnalyzer
+﻿namespace NSonarQubeAnalyzer.Diagnostics
 {
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using System;
+    using System.Collections.Immutable;
+    using System.Linq;
+
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class UseCurlyBraces : DiagnosticAnalyzer
+    public class UseCurlyBraces : DiagnosticsRule
     {
         internal const string DiagnosticId = "S121";
         internal const string Description = "Control structures should always use curly braces";
@@ -23,6 +18,17 @@ namespace NSonarQubeAnalyzer
         internal const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
 
         internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Description, MessageFormat, Category, Severity, true);
+
+        /// <summary>
+        /// Rule ID
+        /// </summary>
+        public override string RuleId
+        {
+            get
+            {
+                return "S121";
+            }
+        }
 
         private class CheckedKind
         {
@@ -81,14 +87,14 @@ namespace NSonarQubeAnalyzer
             context.RegisterSyntaxNodeAction(
                 c =>
                 {
-                    var checkedKind = CheckedKinds.Where(e => c.Node.IsKind(e.Kind)).Single();
+                    var checkedKind = this.CheckedKinds.Where(e => c.Node.IsKind(e.Kind)).Single();
 
                     if (!checkedKind.Validator(c.Node))
                     {
                         c.ReportDiagnostic(Diagnostic.Create(Rule, c.Node.GetLocation(), checkedKind.Value));
                     }
                 },
-                CheckedKinds.Select(e => e.Kind).ToArray());
+                this.CheckedKinds.Select(e => e.Kind).ToArray());
         }
     }
 }

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/DiagnosticsRule.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/DiagnosticsRule.cs
@@ -1,0 +1,24 @@
+﻿namespace NSonarQubeAnalyzer
+{
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using System.Xml.Linq;
+
+    /// <summary>
+    /// Base class for Diagnostics Rules
+    /// </summary>
+    public abstract class DiagnosticsRule : DiagnosticAnalyzer
+    {
+        /// <summary>
+        /// Rule ID
+        /// </summary>
+        public abstract string RuleId { get; }
+
+        /// <summary>
+        /// Configure the rule from the supplied settings
+        /// </summary>
+        /// <param name="settings">XML settings</param>
+        public virtual void Configure(XDocument settings)
+        {
+        }
+    }
+}

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Metrics.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Metrics.cs
@@ -1,16 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Text;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
-
-namespace NSonarQubeAnalyzer
+﻿namespace NSonarQubeAnalyzer
 {
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Text;
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+
     public class FileComments
     {
         public readonly IImmutableSet<int> NoSonar;

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/NSonarQubeAnalyzer.csproj
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/NSonarQubeAnalyzer.csproj
@@ -125,12 +125,15 @@
     <Compile Include="Diagnostics\AtLeastThreeCasesInSwitch.cs" />
     <Compile Include="Diagnostics\SwitchWithoutDefault.cs" />
     <Compile Include="Distribution.cs" />
+    <Compile Include="DiagnosticsRule.cs" />
     <Compile Include="Metrics.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Program.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Program.cs
@@ -147,8 +147,9 @@ namespace NSonarQubeAnalyzer
 
             var diagnosticAnalyzersBuilder = ImmutableArray.CreateBuilder<DiagnosticAnalyzer>();
 
+            var superType = typeof(DiagnosticsRule);
             var activatedRules = from type in Assembly.GetExecutingAssembly().ExportedTypes
-                                 where typeof(DiagnosticsRule).IsAssignableFrom(type)
+                                 where superType.IsAssignableFrom(type) && !type.IsAbstract
                                  let rule = (DiagnosticsRule)Activator.CreateInstance(type)
                                  where rules.Contains(rule.RuleId)
                                  select rule;

--- a/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Program.cs
+++ b/NSonarQubeAnalyzer/NSonarQubeAnalyzer/Program.cs
@@ -1,21 +1,17 @@
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
-using System.IO;
-using System.Xml;
-using System.Xml.Linq;
-using System.Threading;
-
 namespace NSonarQubeAnalyzer
 {
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using System;
+    using System.Collections.Immutable;
+    using System.IO;
+    using System.Linq;
+    using System.Reflection;
+    using System.Text;
+    using System.Xml;
+    using System.Xml.Linq;
+
     public class Program
     {
         public static void Main(string[] args)
@@ -27,249 +23,11 @@ namespace NSonarQubeAnalyzer
             var files = from e in xmlIn.Descendants("File")
                         select e.Value;
             bool ignoreHeaderComments = "true".Equals(settings["sonar.cs.ignoreHeaderComments"]);
-            var rules = (from e in xmlIn.Descendants("Rule")
-                         select e.Elements("Key").Single().Value)
-                         .ToImmutableHashSet();
 
-            var diagnosticAnalyzersBuilder = ImmutableArray.CreateBuilder<DiagnosticAnalyzer>();
-            if (rules.Contains("SwitchWithoutDefault"))
-            {
-                diagnosticAnalyzersBuilder.Add(new SwitchWithoutDefault());
-            }
-            if (rules.Contains("S1301"))
-            {
-                diagnosticAnalyzersBuilder.Add(new AtLeastThreeCasesInSwitch());
-            }
-            if (rules.Contains("BreakOutsideSwitch"))
-            {
-                diagnosticAnalyzersBuilder.Add(new BreakOutsideSwitch());
-            }
-            if (rules.Contains("S1125"))
-            {
-                diagnosticAnalyzersBuilder.Add(new UnnecessaryBooleanLiteral());
-            }
-            if (rules.Contains("S1145"))
-            {
-                diagnosticAnalyzersBuilder.Add(new IfConditionalAlwaysTrueOrFalse());
-            }
-            if (rules.Contains("AsyncAwaitIdentifier"))
-            {
-                diagnosticAnalyzersBuilder.Add(new AsyncAwaitIdentifier());
-            }
-            if (rules.Contains("AssignmentInsideSubExpression"))
-            {
-                diagnosticAnalyzersBuilder.Add(new AssignmentInsideSubExpression());
-            }
-            if (rules.Contains("S126"))
-            {
-                diagnosticAnalyzersBuilder.Add(new ElseIfWithoutElse());
-            }
-            if (rules.Contains("S1116"))
-            {
-                diagnosticAnalyzersBuilder.Add(new EmptyStatement());
-            }
-            if (rules.Contains("S121"))
-            {
-                diagnosticAnalyzersBuilder.Add(new UseCurlyBraces());
-            }
-            if (rules.Contains("S1109"))
-            {
-                diagnosticAnalyzersBuilder.Add(new RightCurlyBraceStartsLine());
-            }
-            if (rules.Contains("TabCharacter"))
-            {
-                diagnosticAnalyzersBuilder.Add(new TabCharacter());
-            }
-            if (rules.Contains("S1186"))
-            {
-                diagnosticAnalyzersBuilder.Add(new EmptyMethod());
-            }
-            if (rules.Contains("S127"))
-            {
-                diagnosticAnalyzersBuilder.Add(new ForLoopCounterChanged());
-            }
-            if (rules.Contains("FileLoc"))
-            {
-                var parameters = from e in xmlIn.Descendants("Rule")
-                                 where "FileLoc".Equals(e.Elements("Key").Single().Value)
-                                 select e.Descendants("Parameter");
-                var maximum = (from e in parameters
-                               where "maximumFileLocThreshold".Equals(e.Elements("Key").Single().Value)
-                               select e.Elements("Value").Single().Value)
-                              .Single();
+            ImmutableArray<DiagnosticAnalyzer> activatedRules = ConfigureActivatedRules(xmlIn);
+            var diagnosticsRunner = new DiagnosticsRunner(activatedRules);
+            var xmlOutSettings = new XmlWriterSettings { Encoding = Encoding.UTF8, Indent = true, IndentChars = "  " };
 
-                var diagnostic = new FileLines();
-                diagnostic.Maximum = int.Parse(maximum);
-                diagnosticAnalyzersBuilder.Add(diagnostic);
-            }
-            if (rules.Contains("LineLength"))
-            {
-                var parameters = from e in xmlIn.Descendants("Rule")
-                                 where "LineLength".Equals(e.Elements("Key").Single().Value)
-                                 select e.Descendants("Parameter");
-                var maximum = (from e in parameters
-                               where "maximumLineLength".Equals(e.Elements("Key").Single().Value)
-                               select e.Elements("Value").Single().Value)
-                              .Single();
-
-                var diagnostic = new LineLength();
-                diagnostic.Maximum = int.Parse(maximum);
-                diagnosticAnalyzersBuilder.Add(diagnostic);
-            }
-            if (rules.Contains("S1479"))
-            {
-                var parameters = from e in xmlIn.Descendants("Rule")
-                                 where "S1479".Equals(e.Elements("Key").Single().Value)
-                                 select e.Descendants("Parameter");
-                var maximum = (from e in parameters
-                               where "maximum".Equals(e.Elements("Key").Single().Value)
-                               select e.Elements("Value").Single().Value)
-                              .Single();
-
-                var diagnostic = new TooManyLabelsInSwitch();
-                diagnostic.Maximum = int.Parse(maximum);
-                diagnosticAnalyzersBuilder.Add(diagnostic);
-            }
-            if (rules.Contains("S107"))
-            {
-                var parameters = from e in xmlIn.Descendants("Rule")
-                                 where "S107".Equals(e.Elements("Key").Single().Value)
-                                 select e.Descendants("Parameter");
-                var maximum = (from e in parameters
-                               where "max".Equals(e.Elements("Key").Single().Value)
-                               select e.Elements("Value").Single().Value)
-                              .Single();
-
-                var diagnostic = new TooManyParameters();
-                diagnostic.Maximum = int.Parse(maximum);
-                diagnosticAnalyzersBuilder.Add(diagnostic);
-            }
-            if (rules.Contains("S101"))
-            {
-                var parameters = from e in xmlIn.Descendants("Rule")
-                                 where "S101".Equals(e.Elements("Key").Single().Value)
-                                 select e.Descendants("Parameter");
-                var convention = (from e in parameters
-                                  where "format".Equals(e.Elements("Key").Single().Value)
-                                  select e.Elements("Value").Single().Value)
-                              .Single();
-
-                var diagnostic = new ClassName();
-                diagnostic.Convention = convention;
-                diagnosticAnalyzersBuilder.Add(diagnostic);
-            }
-            if (rules.Contains("S100"))
-            {
-                var parameters = from e in xmlIn.Descendants("Rule")
-                                 where "S100".Equals(e.Elements("Key").Single().Value)
-                                 select e.Descendants("Parameter");
-                var convention = (from e in parameters
-                                  where "format".Equals(e.Elements("Key").Single().Value)
-                                  select e.Elements("Value").Single().Value)
-                              .Single();
-
-                var diagnostic = new MethodName();
-                diagnostic.Convention = convention;
-                diagnosticAnalyzersBuilder.Add(diagnostic);
-            }
-            if (rules.Contains("MagicNumber"))
-            {
-                var parameters = from e in xmlIn.Descendants("Rule")
-                                 where "MagicNumber".Equals(e.Elements("Key").Single().Value)
-                                 select e.Descendants("Parameter");
-                var exceptions = (from e in parameters
-                                  where "exceptions".Equals(e.Elements("Key").Single().Value)
-                                  select e.Elements("Value").Single().Value)
-                              .Single();
-
-                var diagnostic = new MagicNumber();
-                diagnostic.Exceptions = exceptions.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(e => e.Trim()).ToImmutableHashSet();
-                diagnosticAnalyzersBuilder.Add(diagnostic);
-            }
-            if (rules.Contains("S1067"))
-            {
-                var parameters = from e in xmlIn.Descendants("Rule")
-                                 where "S1067".Equals(e.Elements("Key").Single().Value)
-                                 select e.Descendants("Parameter");
-                var maximum = (from e in parameters
-                               where "max".Equals(e.Elements("Key").Single().Value)
-                               select e.Elements("Value").Single().Value)
-                              .Single();
-
-                var diagnostic = new ExpressionComplexity();
-                diagnostic.Maximum = int.Parse(maximum);
-                diagnosticAnalyzersBuilder.Add(diagnostic);
-            }
-            if (rules.Contains("S108"))
-            {
-                diagnosticAnalyzersBuilder.Add(new EmptyNestedBlock());
-            }
-            if (rules.Contains("ParameterAssignedTo"))
-            {
-                diagnosticAnalyzersBuilder.Add(new ParameterAssignedTo());
-            }
-            if (rules.Contains("S1481"))
-            {
-                diagnosticAnalyzersBuilder.Add(new UnusedLocalVariable());
-            }
-            if (rules.Contains("CommentedCode"))
-            {
-                diagnosticAnalyzersBuilder.Add(new CommentedOutCode());
-            }
-
-            var commentRegexpRules = from e in xmlIn.Descendants("Rule")
-                                     where "S124".Equals((e.Elements("ParentKey").SingleOrDefault() ?? XElement.Parse("<Dummy />")).Value)
-                                     select e;
-            if (commentRegexpRules.Any())
-            {
-                var builder = ImmutableArray.CreateBuilder<CommentRegularExpressionRule>();
-                foreach (var commentRegexpRule in commentRegexpRules)
-                {
-                    string key = commentRegexpRule.Elements("Key").Single().Value;
-                    var parameters = commentRegexpRule.Descendants("Parameter");
-                    string message = (from e in parameters
-                                      where "message".Equals(e.Elements("Key").Single().Value)
-                                      select e.Elements("Value").Single().Value)
-                                  .Single();
-                    string regularExpression = (from e in parameters
-                                                where "regularExpression".Equals(e.Elements("Key").Single().Value)
-                                                select e.Elements("Value").Single().Value)
-                                  .Single();
-
-                    builder.Add(
-                        new CommentRegularExpressionRule
-                        {
-                            // TODO: Add rule description
-                            Descriptor = new DiagnosticDescriptor(key, "TODO", message, "SonarQube", DiagnosticSeverity.Warning, true),
-                            RegularExpression = regularExpression
-                        });
-
-                    var diagnostic = new CommentRegularExpression();
-                    diagnostic.Rules = builder.ToImmutable();
-                    diagnosticAnalyzersBuilder.Add(diagnostic);
-                }
-            }
-            if (rules.Contains("FunctionComplexity"))
-            {
-                var parameters = from e in xmlIn.Descendants("Rule")
-                                 where "FunctionComplexity".Equals(e.Elements("Key").Single().Value)
-                                 select e.Descendants("Parameter");
-                var maximum = (from e in parameters
-                               where "maximumFunctionComplexityThreshold".Equals(e.Elements("Key").Single().Value)
-                               select e.Elements("Value").Single().Value)
-                              .Single();
-
-                var diagnostic = new FunctionComplexity();
-                diagnostic.Maximum = int.Parse(maximum);
-                diagnosticAnalyzersBuilder.Add(diagnostic);
-            }
-
-            var diagnosticsRunner = new DiagnosticsRunner(diagnosticAnalyzersBuilder.ToImmutableArray());
-
-            var xmlOutSettings = new XmlWriterSettings();
-            xmlOutSettings.Encoding = Encoding.UTF8;
-            xmlOutSettings.Indent = true;
-            xmlOutSettings.IndentChars = "  ";
             using (var xmlOut = XmlWriter.Create(args[1], xmlOutSettings))
             {
                 xmlOut.WriteComment("This XML format is not an API");
@@ -374,6 +132,34 @@ namespace NSonarQubeAnalyzer
 
                 xmlOut.Flush();
             }
+        }
+
+        /// <summary>
+        /// Create and configure instances of all rules that are activated
+        /// </summary>
+        /// <param name="xmlIn">XML settings</param>
+        /// <returns>All activated rules</returns>
+        private static ImmutableArray<DiagnosticAnalyzer> ConfigureActivatedRules(XDocument xmlIn)
+        {
+            var rules = (from e in xmlIn.Descendants("Rule")
+                         select e.Elements("Key").Single().Value)
+                         .ToImmutableHashSet();
+
+            var diagnosticAnalyzersBuilder = ImmutableArray.CreateBuilder<DiagnosticAnalyzer>();
+
+            var activatedRules = from type in Assembly.GetExecutingAssembly().ExportedTypes
+                                 where typeof(DiagnosticsRule).IsAssignableFrom(type)
+                                 let rule = (DiagnosticsRule)Activator.CreateInstance(type)
+                                 where rules.Contains(rule.RuleId)
+                                 select rule;
+
+            foreach (DiagnosticsRule rule in activatedRules)
+            {
+                rule.Configure(xmlIn);
+                diagnosticAnalyzersBuilder.Add(rule);
+            }
+
+            return diagnosticAnalyzersBuilder.ToImmutable();
         }
     }
 }

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/AssignmentInsideSubExpressionTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/AssignmentInsideSubExpressionTest.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+
     [TestClass]
     public class AssignmentInsideSubExpressionTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/AsyncAwaitIdentifierTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/AsyncAwaitIdentifierTest.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+
     [TestClass]
     public class AsyncAwaitIdentifierTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/AtLeastThreeCasesInSwitchTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/AtLeastThreeCasesInSwitchTest.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+
     [TestClass]
     public class AtLeastThreeCasesInSwitchTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/BreakOutsideSwitchTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/BreakOutsideSwitchTest.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+
     [TestClass]
     public class BreakOutsideSwitchTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/ClassNameTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/ClassNameTest.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+
     [TestClass]
     public class ClassNameTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/CommentRegularExpressionTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/CommentRegularExpressionTest.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.CodeAnalysis;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+    using System.Collections.Immutable;
+
     [TestClass]
     public class CommentRegularExpressionTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/CommentedOutCodeTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/CommentedOutCodeTest.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+
     [TestClass]
     public class CommentedOutCodeTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/ElseIfWithoutElseTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/ElseIfWithoutElseTest.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+
     [TestClass]
     public class ElseIfWithoutElseTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/EmptyMethodTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/EmptyMethodTest.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+
     [TestClass]
     public class EmptyMethodTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/EmptyNestedBlockTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/EmptyNestedBlockTest.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+
     [TestClass]
     public class EmptyNestedBlockTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/EmptyStatementTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/EmptyStatementTest.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+
     [TestClass]
     public class EmptyStatementTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/ExpressionComplexityTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/ExpressionComplexityTest.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections.Immutable;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+
     [TestClass]
     public class ExpressionComplexityTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/FileLinesTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/FileLinesTest.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+
     [TestClass]
     public class FileLinesTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/ForLoopCounterChangedTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/ForLoopCounterChangedTest.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+
     [TestClass]
     public class ForLoopCounterChangedTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/IfConditionalAlwaysTrueOrFalseTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/IfConditionalAlwaysTrueOrFalseTest.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+
     [TestClass]
     public class IfConditionalAlwaysTrueOrFalseTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/LineLengthTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/LineLengthTest.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+
     [TestClass]
     public class LineLengthTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/MagicNumberTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/MagicNumberTest.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.Collections.Immutable;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+    using System.Collections.Immutable;
+
     [TestClass]
     public class MagicNumberTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/MethodNameTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/MethodNameTest.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+
     [TestClass]
     public class MethodNameTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/ParameterAssignedToTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/ParameterAssignedToTest.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+
     [TestClass]
     public class ParameterAssignedToTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/RightCurlyBraceStartsLineTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/RightCurlyBraceStartsLineTest.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+
     [TestClass]
     public class RightCurlyBraceStartsLineTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/SwitchWithoutDefaultTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/SwitchWithoutDefaultTest.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+
     [TestClass]
     public class SwitchWithoutDefaultTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/TabCharacterTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/TabCharacterTest.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+
     [TestClass]
     public class TabCharacterTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/TooManyLabelsInSwitchTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/TooManyLabelsInSwitchTest.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+
     [TestClass]
     public class TooManyLabelsInSwitchTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/TooManyParametersTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/TooManyParametersTest.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+
     [TestClass]
     public class TooManyParametersTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/UnnecessaryBooleanLiteralTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/UnnecessaryBooleanLiteralTest.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+
     [TestClass]
     public class UnnecessaryBooleanLiteralTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/UnusedLocalVariableTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/UnusedLocalVariableTest.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+
     [TestClass]
     public class UnusedLocalVariableTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/UseCurlyBracesTest.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/UseCurlyBracesTest.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer.Diagnostics;
+
     [TestClass]
     public class UseCurlyBracesTest
     {

--- a/NSonarQubeAnalyzer/Tests/Diagnostics/Verifier.cs
+++ b/NSonarQubeAnalyzer/Tests/Diagnostics/Verifier.cs
@@ -1,18 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.IO;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis;
-using NSonarQubeAnalyzer;
-using System.Collections.Immutable;
-using FluentAssertions;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using FluentAssertions;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using NSonarQubeAnalyzer;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+
     public class Verifier
     {
         public static void Verify(string path, DiagnosticAnalyzer diagnosticAnalyzer)

--- a/NSonarQubeAnalyzer/Tests/MetricsTest.cs
+++ b/NSonarQubeAnalyzer/Tests/MetricsTest.cs
@@ -1,13 +1,12 @@
-﻿using System;
-using System.Collections.Immutable;
-using FluentAssertions;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSonarQubeAnalyzer;
-
-namespace Tests
+﻿namespace Tests
 {
+    using FluentAssertions;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSonarQubeAnalyzer;
+    using System;
+    using System.Collections.Immutable;
+
     [TestClass]
     public class MetricsTest
     {

--- a/NSonarQubeAnalyzer/Tests/TestCases/AssignmentInsideSubExpression.cs
+++ b/NSonarQubeAnalyzer/Tests/TestCases/AssignmentInsideSubExpression.cs
@@ -1,7 +1,7 @@
-﻿using System.Collections.Generic;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using System.Collections.Generic;
+
     public class AssignmentInsideSubExpression
     {
         void Foo(int a)

--- a/NSonarQubeAnalyzer/Tests/TestCases/AsyncAwaitIdentifier.cs
+++ b/NSonarQubeAnalyzer/Tests/TestCases/AsyncAwaitIdentifier.cs
@@ -1,7 +1,7 @@
-﻿using System.Collections.Generic;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using System.Collections.Generic;
+
     public class AsyncAwaitIdentifier
     {
         public AsyncAwaitIdentifier()

--- a/NSonarQubeAnalyzer/Tests/TestCases/BreakOutsideSwitch.cs
+++ b/NSonarQubeAnalyzer/Tests/TestCases/BreakOutsideSwitch.cs
@@ -1,7 +1,7 @@
-﻿using System.Collections.Generic;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using System.Collections.Generic;
+
     public class BreakOutsideSwitch
     {
         public BreakOutsideSwitch(int n)

--- a/NSonarQubeAnalyzer/Tests/TestCases/ElseIfWithoutElse.cs
+++ b/NSonarQubeAnalyzer/Tests/TestCases/ElseIfWithoutElse.cs
@@ -1,7 +1,7 @@
-﻿using System.Collections.Generic;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using System.Collections.Generic;
+
     public class ElseIfWithoutElse
     {
         public ElseIfWithoutElse(bool a)

--- a/NSonarQubeAnalyzer/Tests/TestCases/EmptyMethod.cs
+++ b/NSonarQubeAnalyzer/Tests/TestCases/EmptyMethod.cs
@@ -1,7 +1,7 @@
-﻿using System;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using System;
+
     public class EmptyMethod
     {
         private EmptyMethod()

--- a/NSonarQubeAnalyzer/Tests/TestCases/EmptyNestedBlock.cs
+++ b/NSonarQubeAnalyzer/Tests/TestCases/EmptyNestedBlock.cs
@@ -1,7 +1,7 @@
-﻿using System;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using System;
+
     public class EmptyNestedBlock
     {
         public EmptyNestedBlock()

--- a/NSonarQubeAnalyzer/Tests/TestCases/EmptyStatement.cs
+++ b/NSonarQubeAnalyzer/Tests/TestCases/EmptyStatement.cs
@@ -1,7 +1,7 @@
-﻿using System;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using System;
+
     public class EmptyStatement
     {
         public int MyField;

--- a/NSonarQubeAnalyzer/Tests/TestCases/LineLength.cs
+++ b/NSonarQubeAnalyzer/Tests/TestCases/LineLength.cs
@@ -1,7 +1,7 @@
-﻿using System.Collections.Generic;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using System.Collections.Generic;
+
     public class LineLength
     {
         public LineLength()

--- a/NSonarQubeAnalyzer/Tests/TestCases/ParameterAssignedTo.cs
+++ b/NSonarQubeAnalyzer/Tests/TestCases/ParameterAssignedTo.cs
@@ -1,7 +1,7 @@
-﻿using System;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using System;
+
     public class ParameterAssignedTo
     {
         void f1(int a)

--- a/NSonarQubeAnalyzer/Tests/TestCases/RightCurlyBraceStartsLine.cs
+++ b/NSonarQubeAnalyzer/Tests/TestCases/RightCurlyBraceStartsLine.cs
@@ -1,7 +1,7 @@
-﻿using System.Collections.Generic;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using System.Collections.Generic;
+
     public class RightCurlyBraceStartsLine
     {
         public RightCurlyBraceStartsLine()

--- a/NSonarQubeAnalyzer/Tests/TestCases/TabCharacter.cs
+++ b/NSonarQubeAnalyzer/Tests/TestCases/TabCharacter.cs
@@ -1,7 +1,7 @@
-﻿using System.Collections.Generic;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using System.Collections.Generic;
+
     public class RightCurlyBraceStartsLine
     {
         public RightCurlyBraceStartsLine()

--- a/NSonarQubeAnalyzer/Tests/TestCases/UnusedLocalVariable.cs
+++ b/NSonarQubeAnalyzer/Tests/TestCases/UnusedLocalVariable.cs
@@ -1,7 +1,7 @@
-﻿using System;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using System;
+
     public class UnusedLocalVariable
     {
         void F1()

--- a/NSonarQubeAnalyzer/Tests/TestCases/UseCurlyBraces.cs
+++ b/NSonarQubeAnalyzer/Tests/TestCases/UseCurlyBraces.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+
     public class UseCurlyBraces
     {
         public UseCurlyBraces()


### PR DESCRIPTION
The previous solution relied on a huge sequence of if statements to check for
each rule whether it was activated or not and configure it if so.

The new solution improves on that by dynamically creating and configuring any
class that implements the common generic class DiagnosticsRule. This means
that new rules will be discovered at runtime and created automatically instead
of having to remember to add the rule to the list in Program.cs.