### PR TITLE
SONARFXCOP-40 Run FxCop using the "/ignoregeneratedcode" switch

### DIFF
--- a/sonar-csharp-plugin/pom.xml
+++ b/sonar-csharp-plugin/pom.xml
@@ -56,6 +56,7 @@
     <dependency>
       <groupId>org.codehaus.sonar.dotnet.fxcop</groupId>
       <artifactId>sonar-fxcop-library</artifactId>
+      <version>1.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.sonar.dotnet.tests</groupId>

--- a/sonar-csharp-plugin/pom.xml
+++ b/sonar-csharp-plugin/pom.xml
@@ -56,7 +56,6 @@
     <dependency>
       <groupId>org.codehaus.sonar.dotnet.fxcop</groupId>
       <artifactId>sonar-fxcop-library</artifactId>
-      <version>1.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.sonar.dotnet.tests</groupId>

--- a/sonar-csharp-plugin/src/main/java/org/sonar/plugins/csharp/core/CSharpFxCopProvider.java
+++ b/sonar-csharp-plugin/src/main/java/org/sonar/plugins/csharp/core/CSharpFxCopProvider.java
@@ -44,7 +44,6 @@ public class CSharpFxCopProvider {
   private static final String FXCOP_FXCOPCMD_PATH_PROPERTY_KEY = "sonar.cs.fxcop.fxCopCmdPath";
   private static final String FXCOP_TIMEOUT_PROPERTY_KEY = "sonar.cs.fxcop.timeoutMinutes";
   private static final String FXCOP_ASPNET_PROPERTY_KEY = "sonar.cs.fxcop.aspnet";
-  private static final String FXCOP_IGNOREGENERATEDCODE_PROPERTY_KEY = "sonar.cs.fxcop.ignoreGeneratedCode";
   private static final String FXCOP_DIRECTORIES_PROPERTY_KEY = "sonar.cs.fxcop.directories";
   private static final String FXCOP_REFERENCES_PROPERTY_KEY = "sonar.cs.fxcop.references";
 
@@ -55,7 +54,6 @@ public class CSharpFxCopProvider {
     FXCOP_FXCOPCMD_PATH_PROPERTY_KEY,
     FXCOP_TIMEOUT_PROPERTY_KEY,
     FXCOP_ASPNET_PROPERTY_KEY,
-    FXCOP_IGNOREGENERATEDCODE_PROPERTY_KEY,
     FXCOP_DIRECTORIES_PROPERTY_KEY,
     FXCOP_REFERENCES_PROPERTY_KEY);
 
@@ -95,14 +93,6 @@ public class CSharpFxCopProvider {
         .subCategory(SUBCATEGORY)
         .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .build(),
-      PropertyDefinition.builder(FXCOP_IGNOREGENERATEDCODE_PROPERTY_KEY)
-            .name("Ignore generated code")
-            .description("Whether or not to set the /igc flag when launching FxCopCmd.exe")
-            .defaultValue("false" )
-            .category(CATEGORY)
-            .subCategory(SUBCATEGORY)
-            .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
-            .build(),
       PropertyDefinition.builder(FXCOP_DIRECTORIES_PROPERTY_KEY)
         .name("Additional assemblies directories")
         .description("Comma-separated list of directories where FxCop should look for referenced assemblies. Example: c:/MyLibrary")

--- a/sonar-csharp-plugin/src/main/java/org/sonar/plugins/csharp/core/CSharpFxCopProvider.java
+++ b/sonar-csharp-plugin/src/main/java/org/sonar/plugins/csharp/core/CSharpFxCopProvider.java
@@ -44,6 +44,7 @@ public class CSharpFxCopProvider {
   private static final String FXCOP_FXCOPCMD_PATH_PROPERTY_KEY = "sonar.cs.fxcop.fxCopCmdPath";
   private static final String FXCOP_TIMEOUT_PROPERTY_KEY = "sonar.cs.fxcop.timeoutMinutes";
   private static final String FXCOP_ASPNET_PROPERTY_KEY = "sonar.cs.fxcop.aspnet";
+  private static final String FXCOP_IGNOREGENERATEDCODE_PROPERTY_KEY = "sonar.cs.fxcop.ignoreGeneratedCode";
   private static final String FXCOP_DIRECTORIES_PROPERTY_KEY = "sonar.cs.fxcop.directories";
   private static final String FXCOP_REFERENCES_PROPERTY_KEY = "sonar.cs.fxcop.references";
 
@@ -54,6 +55,7 @@ public class CSharpFxCopProvider {
     FXCOP_FXCOPCMD_PATH_PROPERTY_KEY,
     FXCOP_TIMEOUT_PROPERTY_KEY,
     FXCOP_ASPNET_PROPERTY_KEY,
+    FXCOP_IGNOREGENERATEDCODE_PROPERTY_KEY,
     FXCOP_DIRECTORIES_PROPERTY_KEY,
     FXCOP_REFERENCES_PROPERTY_KEY);
 
@@ -93,6 +95,14 @@ public class CSharpFxCopProvider {
         .subCategory(SUBCATEGORY)
         .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
         .build(),
+      PropertyDefinition.builder(FXCOP_IGNOREGENERATEDCODE_PROPERTY_KEY)
+            .name("Ignore generated code")
+            .description("Whether or not to set the /igc flag when launching FxCopCmd.exe")
+            .defaultValue("false" )
+            .category(CATEGORY)
+            .subCategory(SUBCATEGORY)
+            .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+            .build(),
       PropertyDefinition.builder(FXCOP_DIRECTORIES_PROPERTY_KEY)
         .name("Additional assemblies directories")
         .description("Comma-separated list of directories where FxCop should look for referenced assemblies. Example: c:/MyLibrary")

--- a/sonar-csharp-plugin/src/main/java/org/sonar/plugins/csharp/core/CSharpFxCopProvider.java
+++ b/sonar-csharp-plugin/src/main/java/org/sonar/plugins/csharp/core/CSharpFxCopProvider.java
@@ -98,10 +98,10 @@ public class CSharpFxCopProvider {
       PropertyDefinition.builder(FXCOP_IGNOREGENERATEDCODE_PROPERTY_KEY)
             .name("Ignore generated code")
             .description("Whether or not to set the /igc flag when launching FxCopCmd.exe")
-            .defaultValue("false" )
+            .defaultValue("true" )
             .category(CATEGORY)
             .subCategory(SUBCATEGORY)
-            .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+            .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
             .build(),
       PropertyDefinition.builder(FXCOP_DIRECTORIES_PROPERTY_KEY)
         .name("Additional assemblies directories")

--- a/sonar-csharp-plugin/src/test/java/org/sonar/plugins/csharp/core/CSharpFxCopProviderTest.java
+++ b/sonar-csharp-plugin/src/test/java/org/sonar/plugins/csharp/core/CSharpFxCopProviderTest.java
@@ -42,6 +42,7 @@ public class CSharpFxCopProviderTest {
       "sonar.cs.fxcop.timeoutMinutes",
       "sonar.cs.fxcop.fxCopCmdPath",
       "sonar.cs.fxcop.aspnet",
+      "sonar.cs.fxcop.ignoreGeneratedCode",
       "sonar.cs.fxcop.directories",
       "sonar.cs.fxcop.references");
   }

--- a/sonar-csharp-plugin/src/test/java/org/sonar/plugins/csharp/core/CSharpFxCopProviderTest.java
+++ b/sonar-csharp-plugin/src/test/java/org/sonar/plugins/csharp/core/CSharpFxCopProviderTest.java
@@ -42,7 +42,6 @@ public class CSharpFxCopProviderTest {
       "sonar.cs.fxcop.timeoutMinutes",
       "sonar.cs.fxcop.fxCopCmdPath",
       "sonar.cs.fxcop.aspnet",
-      "sonar.cs.fxcop.ignoreGeneratedCode",
       "sonar.cs.fxcop.directories",
       "sonar.cs.fxcop.references");
   }


### PR DESCRIPTION
Added support for ignoring generated code in FxCop. As described on jira.

These changes need to be applied together with the changes on the fx-cop plugin (I also created a pull request for these changes) [SonarCommunity/sonar-fxcop-library#6](https://github.com/SonarCommunity/sonar-fxcop-library/pull/6)